### PR TITLE
Feat student test

### DIFF
--- a/src/components/MultipleChoiceQuestion.jsx
+++ b/src/components/MultipleChoiceQuestion.jsx
@@ -1,5 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Radio, Form } from 'antd';
 
 export default function MultipleChoiceQuestion() {
-  return <div>Multiple-choice question card</div>;
+  const [value, setValue] = useState('');
+
+  const radioStyle = {
+    display: 'block',
+    height: '30px',
+    lineHeight: '30px',
+  };
+
+  return (
+    <Form.Item label="Question 1">
+      <br />
+      <Radio.Group onChange={(e) => setValue(e.target.value)} value={value}>
+        <Radio style={radioStyle} value={1}>
+          Option A
+        </Radio>
+        <Radio style={radioStyle} value={2}>
+          Option B
+        </Radio>
+        <Radio style={radioStyle} value={3}>
+          Option C
+        </Radio>
+        <Radio style={radioStyle} value={4}>
+          Option D
+        </Radio>
+      </Radio.Group>
+    </Form.Item>
+  );
 }

--- a/src/components/MultipleChoiceQuestion.jsx
+++ b/src/components/MultipleChoiceQuestion.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Radio, Form } from 'antd';
 
-export default function MultipleChoiceQuestion() {
+export default function MultipleChoiceQuestion({ text, answers }) {
   const [value, setValue] = useState('');
+
+  const mixedAnswers = answers.map((a) => a.text);
 
   const radioStyle = {
     display: 'block',
@@ -11,20 +13,20 @@ export default function MultipleChoiceQuestion() {
   };
 
   return (
-    <Form.Item label="Question 1">
+    <Form.Item label={text}>
       <br />
       <Radio.Group onChange={(e) => setValue(e.target.value)} value={value}>
         <Radio style={radioStyle} value={1}>
-          Option A
+          {mixedAnswers[0]}
         </Radio>
         <Radio style={radioStyle} value={2}>
-          Option B
+          {mixedAnswers[1]}
         </Radio>
         <Radio style={radioStyle} value={3}>
-          Option C
+          {mixedAnswers[2]}
         </Radio>
         <Radio style={radioStyle} value={4}>
-          Option D
+          {mixedAnswers[3]}
         </Radio>
       </Radio.Group>
     </Form.Item>

--- a/src/components/MultipleChoiceQuestion.jsx
+++ b/src/components/MultipleChoiceQuestion.jsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Radio, Form } from 'antd';
 
-export default function MultipleChoiceQuestion({ text, answers }) {
-  const [value, setValue] = useState('');
-
-  const mixedAnswers = answers.map((a) => a.text);
-
+export default function MultipleChoiceQuestion({
+  text,
+  answers,
+  onPick,
+  questionNumber,
+}) {
   const radioStyle = {
     display: 'block',
     height: '30px',
@@ -14,20 +15,18 @@ export default function MultipleChoiceQuestion({ text, answers }) {
 
   return (
     <Form.Item label={text}>
-      <br />
-      <Radio.Group onChange={(e) => setValue(e.target.value)} value={value}>
-        <Radio style={radioStyle} value={1}>
-          {mixedAnswers[0]}
-        </Radio>
-        <Radio style={radioStyle} value={2}>
-          {mixedAnswers[1]}
-        </Radio>
-        <Radio style={radioStyle} value={3}>
-          {mixedAnswers[2]}
-        </Radio>
-        <Radio style={radioStyle} value={4}>
-          {mixedAnswers[3]}
-        </Radio>
+      <Radio.Group onChange={(e) => onPick(e.target)}>
+        {answers.map(({ text, id, questionId }, i) => (
+          <Radio
+            key={i}
+            style={radioStyle}
+            value={id}
+            questionId={questionId}
+            questionNumber={questionNumber}
+          >
+            {text}
+          </Radio>
+        ))}
       </Radio.Group>
     </Form.Item>
   );

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
 
 export default function StudentDoTest() {
-  return <div>test for a student</div>;
+  return (
+    <div>
+      test for a student
+      <MultipleChoiceQuestion />
+    </div>
+  );
 }

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -1,11 +1,36 @@
 import React from 'react';
+import { useParams, useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectStudentId } from '../../store/student/selectors';
+import { Layout, Button, Row } from 'antd';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
 
+const { Content } = Layout;
+
 export default function StudentDoTest() {
+  const studentId = useSelector(selectStudentId);
+  const { subjectid } = useParams();
+  const history = useHistory();
+
+  const onFinish = () => {
+    console.log('you have finished your test');
+
+    history.push(`/students/${studentId}`);
+  };
+
   return (
-    <div>
-      test for a student
-      <MultipleChoiceQuestion />
-    </div>
+    <Layout>
+      <Layout style={{ padding: '24px', minHeight: '92vh' }}>
+        <Content className="site-layout-background">
+          <Row>
+            hello student #{studentId}, a test for subject #{subjectid} arrrggh
+          </Row>
+          <MultipleChoiceQuestion />
+          <MultipleChoiceQuestion />
+          <MultipleChoiceQuestion />
+          <Button onClick={onFinish}>Finish</Button>
+        </Content>
+      </Layout>
+    </Layout>
   );
 }

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -3,6 +3,7 @@ import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
 import { getMcQuestionsForTest } from '../../store/test/actions';
+import { select3mcQuestionsForSubject } from '../../store/test/selectors';
 import { Layout, Button, Row } from 'antd';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
 
@@ -10,9 +11,10 @@ const { Content } = Layout;
 
 export default function StudentDoTest() {
   const dispatch = useDispatch();
+  const history = useHistory();
   const studentId = useSelector(selectStudentId);
   const { subjectid } = useParams();
-  const history = useHistory();
+  const questions = useSelector(select3mcQuestionsForSubject);
 
   const onFinish = () => {
     console.log('you have finished your test');
@@ -31,9 +33,12 @@ export default function StudentDoTest() {
           <Row>
             hello student #{studentId}, a test for subject #{subjectid} arrrggh
           </Row>
-          <MultipleChoiceQuestion />
-          <MultipleChoiceQuestion />
-          <MultipleChoiceQuestion />
+          {questions
+            ? questions.map(({ text, answers }, i) => (
+                <MultipleChoiceQuestion key={i} text={text} answers={answers} />
+              ))
+            : null}
+
           <Button onClick={onFinish}>Finish</Button>
         </Content>
       </Layout>

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
-import { getMcQuestionsForTest } from '../../store/test/actions';
+import { getMcQuestionsForTest, eraseTest } from '../../store/test/actions';
 import { select3mcQuestionsForSubject } from '../../store/test/selectors';
 import { Layout, Button, Row } from 'antd';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
@@ -32,7 +32,7 @@ export default function StudentDoTest() {
       question2,
       question3
     );
-
+    dispatch(eraseTest());
     history.push(`/students/${studentId}`);
   };
 

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
-import { getMcQuestionsForTest, eraseTest } from '../../store/test/actions';
+import { getMcQuestionsForTest, submitTest } from '../../store/test/actions';
 import { select3mcQuestionsForSubject } from '../../store/test/selectors';
 import { Layout, Button, Row } from 'antd';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
@@ -23,16 +23,18 @@ export default function StudentDoTest() {
   const [question3, setQuestion3] = useState(0);
 
   const onFinish = () => {
-    console.log(
-      'you have finished your test',
-      answer1,
-      answer2,
-      answer3,
-      question1,
-      question2,
-      question3
+    dispatch(
+      submitTest(
+        studentId,
+        subjectid,
+        question1,
+        question2,
+        question3,
+        answer1,
+        answer2,
+        answer3
+      )
     );
-    dispatch(eraseTest());
     history.push(`/students/${studentId}`);
   };
 

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
+import { getMcQuestionsForTest } from '../../store/test/actions';
 import { Layout, Button, Row } from 'antd';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
 
 const { Content } = Layout;
 
 export default function StudentDoTest() {
+  const dispatch = useDispatch();
   const studentId = useSelector(selectStudentId);
   const { subjectid } = useParams();
   const history = useHistory();
@@ -17,6 +19,10 @@ export default function StudentDoTest() {
 
     history.push(`/students/${studentId}`);
   };
+
+  useEffect(() => {
+    dispatch(getMcQuestionsForTest(subjectid));
+  }, [dispatch, subjectid]);
 
   return (
     <Layout>

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
@@ -15,11 +15,39 @@ export default function StudentDoTest() {
   const studentId = useSelector(selectStudentId);
   const { subjectid } = useParams();
   const questions = useSelector(select3mcQuestionsForSubject);
+  const [answer1, setAnswer1] = useState(0);
+  const [answer2, setAnswer2] = useState(0);
+  const [answer3, setAnswer3] = useState(0);
+  const [question1, setQuestion1] = useState(0);
+  const [question2, setQuestion2] = useState(0);
+  const [question3, setQuestion3] = useState(0);
 
   const onFinish = () => {
-    console.log('you have finished your test');
+    console.log(
+      'you have finished your test',
+      answer1,
+      answer2,
+      answer3,
+      question1,
+      question2,
+      question3
+    );
 
     history.push(`/students/${studentId}`);
+  };
+
+  const onPick = (e) => {
+    console.log(e);
+    if (e.questionNumber * 1 === 1) {
+      setQuestion1(e.questionId);
+      e.value === 1 || e.value % 4 === 1 ? setAnswer1(1) : setAnswer1(0);
+    } else if (e.questionNumber === 2) {
+      setQuestion2(e.questionId);
+      e.value === 1 || e.value % 4 === 1 ? setAnswer2(1) : setAnswer2(0);
+    } else {
+      setQuestion3(e.questionId);
+      e.value === 1 || e.value % 4 === 1 ? setAnswer3(1) : setAnswer3(0);
+    }
   };
 
   useEffect(() => {
@@ -34,8 +62,14 @@ export default function StudentDoTest() {
             hello student #{studentId}, a test for subject #{subjectid} arrrggh
           </Row>
           {questions
-            ? questions.map(({ text, answers }, i) => (
-                <MultipleChoiceQuestion key={i} text={text} answers={answers} />
+            ? questions.map(({ text, answers, id }, i) => (
+                <MultipleChoiceQuestion
+                  key={i}
+                  text={text}
+                  answers={answers}
+                  onPick={onPick}
+                  questionNumber={i + 1}
+                />
               ))
             : null}
 

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -1,14 +1,35 @@
 import React from 'react';
-import { Layout } from 'antd';
+import { useParams, useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectStudentId } from '../../store/student/selectors';
+import { Layout, Button, Row } from 'antd';
 
+// import StudentSubjectChart from './StudentSubjectChart';
 const { Content } = Layout;
 
 export default function StudentSubjectDetails() {
+  const studentId = useSelector(selectStudentId);
+  const { subjectid } = useParams();
+  const history = useHistory();
+
+  const goTo = (goto) => {
+    history.push(goto);
+  };
+
   return (
     <Layout>
-      <Layout style={{ padding: '24px', height: '92vh' }}>
+      <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
-          details for a subject for a student
+          <Row> details for a subject for a student</Row>
+          <Row>
+            <Button
+              onClick={() =>
+                goTo(`/students/${studentId}/subjects/${subjectid}/test`)
+              }
+            >
+              Do a test
+            </Button>
+          </Row>
         </Content>
       </Layout>
     </Layout>

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -4,6 +4,7 @@ import schoolInfo from './schoolInfo/reducer';
 import student from './student/reducer';
 import teacher from './teacher/reducer';
 import questions from './questions/reducer';
+import test from './test/reducer';
 
 export default combineReducers({
   appState,
@@ -11,4 +12,5 @@ export default combineReducers({
   student,
   teacher,
   questions,
+  test,
 });

--- a/src/store/test/actions.js
+++ b/src/store/test/actions.js
@@ -69,6 +69,7 @@ export function submitTest(studentId, subjectId, q1, q2, q3, a1, a2, a3) {
       );
 
       dispatch(showMessageWithTimeout('success', true, response.data.message));
+      eraseTest();
       dispatch(appDoneLoading());
     } catch (error) {
       if (error.response) {
@@ -78,7 +79,7 @@ export function submitTest(studentId, subjectId, q1, q2, q3, a1, a2, a3) {
         console.log(error.message);
         dispatch(setMessage('danger', true, error.message));
       }
-      eraseTest();
+
       dispatch(appDoneLoading());
     }
   };

--- a/src/store/test/actions.js
+++ b/src/store/test/actions.js
@@ -4,7 +4,7 @@ import {
   appLoading,
   appDoneLoading,
   setMessage,
-  // showMessageWithTimeout,
+  showMessageWithTimeout,
 } from '../appState/actions';
 
 export const FETCH_MC_QUESTIONS = 'FETCH_QUESTIONS';
@@ -45,5 +45,41 @@ export function getMcQuestionsForTest(id) {
 export function eraseTest() {
   return {
     type: ERASE_TEST,
+  };
+}
+
+export function submitTest(studentId, subjectId, q1, q2, q3, a1, a2, a3) {
+  return async function thunk(dispatch, getState) {
+    const token = getState().student.token;
+    dispatch(appLoading());
+    try {
+      const response = await axios.post(
+        `${apiUrl}/questions/3qtest`,
+        {
+          studentId,
+          subjectId,
+          q1,
+          q2,
+          q3,
+          a1,
+          a2,
+          a3,
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+
+      dispatch(showMessageWithTimeout('success', true, response.data.message));
+      dispatch(appDoneLoading());
+    } catch (error) {
+      if (error.response) {
+        console.log(error.response.data.message);
+        dispatch(setMessage('danger', true, error.response.data.message));
+      } else {
+        console.log(error.message);
+        dispatch(setMessage('danger', true, error.message));
+      }
+      eraseTest();
+      dispatch(appDoneLoading());
+    }
   };
 }

--- a/src/store/test/actions.js
+++ b/src/store/test/actions.js
@@ -10,7 +10,6 @@ import {
 export const FETCH_MC_QUESTIONS = 'FETCH_QUESTIONS';
 
 export function questionsFetched(questions) {
-  console.log('is this thing called?', questions);
   return {
     type: FETCH_MC_QUESTIONS,
     payload: questions,
@@ -18,7 +17,6 @@ export function questionsFetched(questions) {
 }
 
 export function getMcQuestionsForTest(id) {
-  console.log('action is called');
   return async function thunk(dispatch, getState) {
     const token = getState().student.token;
     dispatch(appLoading());
@@ -29,7 +27,6 @@ export function getMcQuestionsForTest(id) {
       const questions = response.data;
 
       dispatch(questionsFetched(questions));
-      console.log(questions);
       dispatch(appDoneLoading());
     } catch (error) {
       if (error.response) {

--- a/src/store/test/actions.js
+++ b/src/store/test/actions.js
@@ -69,7 +69,7 @@ export function submitTest(studentId, subjectId, q1, q2, q3, a1, a2, a3) {
       );
 
       dispatch(showMessageWithTimeout('success', true, response.data.message));
-      eraseTest();
+      dispatch(eraseTest());
       dispatch(appDoneLoading());
     } catch (error) {
       if (error.response) {

--- a/src/store/test/actions.js
+++ b/src/store/test/actions.js
@@ -8,6 +8,7 @@ import {
 } from '../appState/actions';
 
 export const FETCH_MC_QUESTIONS = 'FETCH_QUESTIONS';
+export const ERASE_TEST = 'ERASE_TEST';
 
 export function questionsFetched(questions) {
   return {
@@ -38,5 +39,11 @@ export function getMcQuestionsForTest(id) {
       }
       dispatch(appDoneLoading());
     }
+  };
+}
+
+export function eraseTest() {
+  return {
+    type: ERASE_TEST,
   };
 }

--- a/src/store/test/actions.js
+++ b/src/store/test/actions.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { apiUrl } from '../../config/constants';
+import {
+  appLoading,
+  appDoneLoading,
+  setMessage,
+  // showMessageWithTimeout,
+} from '../appState/actions';
+
+export const FETCH_MC_QUESTIONS = 'FETCH_QUESTIONS';
+
+export function questionsFetched(questions) {
+  console.log('is this thing called?', questions);
+  return {
+    type: FETCH_MC_QUESTIONS,
+    payload: questions,
+  };
+}
+
+export function getMcQuestionsForTest(id) {
+  console.log('action is called');
+  return async function thunk(dispatch, getState) {
+    const token = getState().student.token;
+    dispatch(appLoading());
+    try {
+      const response = await axios.get(`${apiUrl}/questions/3qtest/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const questions = response.data;
+
+      dispatch(questionsFetched(questions));
+      console.log(questions);
+      dispatch(appDoneLoading());
+    } catch (error) {
+      if (error.response) {
+        console.log(error.response.data.message);
+        dispatch(setMessage('danger', true, error.response.data.message));
+      } else {
+        console.log(error.message);
+        dispatch(setMessage('danger', true, error.message));
+      }
+      dispatch(appDoneLoading());
+    }
+  };
+}

--- a/src/store/test/reducer.js
+++ b/src/store/test/reducer.js
@@ -5,10 +5,8 @@ const initialState = {
 };
 
 export default (state = initialState, action) => {
-  console.log('what is in the payload:', action.payload);
   switch (action.type) {
     case FETCH_MC_QUESTIONS:
-      console.log('in the switch', action.payload);
       return { ...state, all: state.all.concat(action.payload) };
 
     default:

--- a/src/store/test/reducer.js
+++ b/src/store/test/reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_MC_QUESTIONS } from './actions';
+import { FETCH_MC_QUESTIONS, ERASE_TEST } from './actions';
 
 const initialState = {
   all: [],
@@ -8,7 +8,8 @@ export default (state = initialState, action) => {
   switch (action.type) {
     case FETCH_MC_QUESTIONS:
       return { ...state, all: state.all.concat(action.payload) };
-
+    case ERASE_TEST:
+      return initialState;
     default:
       return state;
   }

--- a/src/store/test/reducer.js
+++ b/src/store/test/reducer.js
@@ -1,0 +1,17 @@
+import { FETCH_MC_QUESTIONS } from './actions';
+
+const initialState = {
+  all: [],
+};
+
+export default (state = initialState, action) => {
+  console.log('what is in the payload:', action.payload);
+  switch (action.type) {
+    case FETCH_MC_QUESTIONS:
+      console.log('in the switch', action.payload);
+      return { ...state, all: state.all.concat(action.payload) };
+
+    default:
+      return state;
+  }
+};

--- a/src/store/test/selectors.js
+++ b/src/store/test/selectors.js
@@ -1,0 +1,3 @@
+export const select3mcQuestionsForSubject = (state) => {
+  return state.test.all;
+};


### PR DESCRIPTION
Challenging (logic) but fun section.

When a student clicks on 'Do test' the back-end sends 3 random questions for that subject.

When the test is finished  a post request is made with studentId, subjectId, question 1, 2, 3 and answer 1, 2 and 3.
The questions have the value of the questionId, the answers are 1 when correct and 0 when incorrect.
A new row is created in the tests-table.

As I wrote earlier, a better way would be to return the answerId instead of 0/1. This would enable a more detailed analysis. This could be something to implement in the near future. 

TODO:
Now the answers are displayed in order -true-false-false-false- so you know which one is the right one. I will randomize this answers array. With the answerId already there this should be no problem.

Now the student can leave halfway. I want this to be impossible. When a student clicks on do test, he/she must do that test. I will do some research for that feature.

<img width="682" alt="Schermafbeelding 2020-07-01 om 15 50 03" src="https://user-images.githubusercontent.com/60842970/86252535-a4676100-bbb3-11ea-928f-16df1496eac3.png">
