### PR TITLE
Feat student details

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "antd": "^4.3.5",
     "axios": "^0.19.2",
     "chart.js": "^2.9.3",
+    "moment": "^2.27.0",
     "react": "^16.13.1",
     "react-chartjs-2": "^2.9.0",
     "react-dom": "^16.13.1",

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import BarAtTheTop from './components/BarAtThetop';
 import AlertBox from './components/AlertBox';
 import Spinner from './components/Spinner';
 import Sidebar from './components/Sidebar';
-import Home from './pages/Home';
+import Home from './pages/home/';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import StudentMainPage from './pages/student/StudentMainPage';

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Layout } from 'antd';
 import BarAtTheTop from './components/BarAtThetop';
 import AlertBox from './components/AlertBox';
-import Spinner from './components/Spinner';
+// import Spinner from './components/Spinner';
 import Sidebar from './components/Sidebar';
 import Home from './pages/home/';
 import Login from './pages/Login';
@@ -17,7 +17,7 @@ import TeacherStudentDetails from './pages/teacher/TeacherStudentDetails';
 import TeacherSubjectDetails from './pages/teacher/TeacherSubjectDetails';
 import AddQuestionForm from './pages/teacher/AddQuestionForm';
 import ListOfQuestions from './pages/teacher/ListOfQuestions';
-import { selectAppLoading } from './store/appState/selectors';
+// import { selectAppLoading } from './store/appState/selectors';
 import { selectTeacherToken } from './store/teacher/selectors';
 import { getStudentWithStoredToken } from './store/student/actions';
 import { getTeacherWithStoredToken } from './store/teacher/actions';
@@ -26,7 +26,7 @@ import './App.css';
 
 function App() {
   const dispatch = useDispatch();
-  const isLoading = useSelector(selectAppLoading);
+  // const isLoading = useSelector(selectAppLoading);
   const teacherToken = useSelector(selectTeacherToken);
 
   useEffect(() => {
@@ -43,7 +43,7 @@ function App() {
       <AlertBox />
       <Layout>
         <Sidebar />
-        {isLoading ? <Spinner /> : null}
+        {/* {isLoading ? <Spinner /> : null} */}
         <Switch>
           <Route exact path="/" component={Home} />
           <Route exact path="/login" component={Login} />

--- a/src/components/charts/BarChart.jsx
+++ b/src/components/charts/BarChart.jsx
@@ -21,9 +21,10 @@ export default function BarChart({ labels, data, color }) {
         tooltips: false,
         legend: {
           display: false,
+          labels: { fontSize: 16 },
         },
         responsive: true,
-        title: { display: true },
+        title: { text: 'TESTS RESULTS', display: true },
         scales: {
           yAxes: [
             {
@@ -31,7 +32,7 @@ export default function BarChart({ labels, data, color }) {
                 autoSkip: true,
                 maxTicksLimit: 10,
                 beginAtZero: true,
-                display: false,
+                stepSize: 1,
               },
               gridLines: {
                 display: false,
@@ -42,11 +43,6 @@ export default function BarChart({ labels, data, color }) {
             {
               gridLines: {
                 display: false,
-              },
-              ticks: {
-                fontSize: 18,
-                padding: 0,
-                fontColor: '#000',
               },
             },
           ],

--- a/src/components/charts/BarChart.jsx
+++ b/src/components/charts/BarChart.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Bar } from 'react-chartjs-2';
 
-export default function BarChart({ labels, data, color }) {
+export default function BarChart({ labels, data, color, title }) {
   const chartData = {
     labels: labels,
     datasets: [
@@ -24,7 +24,7 @@ export default function BarChart({ labels, data, color }) {
           labels: { fontSize: 16 },
         },
         responsive: true,
-        title: { text: 'TESTS RESULTS', display: true },
+        title: { text: title, display: true },
         scales: {
           yAxes: [
             {

--- a/src/components/charts/DoughnutChart.jsx
+++ b/src/components/charts/DoughnutChart.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Doughnut } from 'react-chartjs-2';
+
+export default function DoughnutChart({ data, color, title }) {
+  const chartData = {
+    datasets: [
+      {
+        label: { display: false },
+        data: data,
+        backgroundColor: color,
+        borderWidth: 0,
+      },
+    ],
+  };
+
+  return (
+    <Doughnut
+      data={chartData}
+      options={{
+        tooltips: false,
+        legend: {
+          display: false,
+          labels: { fontSize: 16 },
+        },
+        responsive: true,
+        title: { text: title, display: true },
+      }}
+    />
+  );
+}

--- a/src/pages/home/BarChartHome.jsx
+++ b/src/pages/home/BarChartHome.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+
+export default function BarChartHome({ labels, data, color }) {
+  const chartData = {
+    labels: labels,
+    datasets: [
+      {
+        label: { display: false },
+        data: data,
+        backgroundColor: color,
+        borderWidth: 0,
+      },
+    ],
+  };
+
+  return (
+    <Bar
+      data={chartData}
+      options={{
+        tooltips: false,
+        legend: {
+          display: false,
+        },
+        responsive: true,
+        title: { display: true },
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                autoSkip: true,
+                maxTicksLimit: 10,
+                beginAtZero: true,
+                display: false,
+              },
+              gridLines: {
+                display: false,
+              },
+            },
+          ],
+          xAxes: [
+            {
+              gridLines: {
+                display: false,
+              },
+              ticks: {
+                fontSize: 18,
+                padding: 0,
+                fontColor: '#000',
+              },
+            },
+          ],
+        },
+      }}
+    />
+  );
+}

--- a/src/pages/home/LineChartHome.jsx
+++ b/src/pages/home/LineChartHome.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+
+export default function LineChartHome({ labels, color, data }) {
+  const chartData = {
+    labels: labels,
+    datasets: [
+      {
+        label: { display: false },
+        data: data,
+        backgroundColor: color,
+        borderWidth: 3,
+      },
+    ],
+  };
+
+  return (
+    <Line
+      data={chartData}
+      options={{
+        tooltips: false,
+        legend: {
+          display: false,
+        },
+        responsive: true,
+        title: { display: true },
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                autoSkip: true,
+                maxTicksLimit: 10,
+                beginAtZero: true,
+                display: false,
+              },
+              gridLines: {
+                display: false,
+              },
+            },
+          ],
+          xAxes: [
+            {
+              gridLines: {
+                display: false,
+              },
+              ticks: {
+                fontSize: 18,
+                padding: 0,
+                fontColor: '#000',
+              },
+            },
+          ],
+        },
+      }}
+    />
+  );
+}

--- a/src/pages/home/PolarChartHome.jsx
+++ b/src/pages/home/PolarChartHome.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Polar } from 'react-chartjs-2';
+
+export default function PolarChartHome({ labels, color, data }) {
+  const chartData = {
+    labels: labels,
+    datasets: [
+      {
+        label: { display: false },
+        data: data,
+        backgroundColor: color,
+        borderWidth: 0,
+      },
+    ],
+  };
+
+  return (
+    <Polar
+      data={chartData}
+      options={{
+        tooltips: false,
+        legend: {
+          display: true,
+          position: 'bottom',
+          labels: { fontSize: 18 },
+        },
+        responsive: true,
+        title: { display: false },
+        scale: {
+          display: false,
+        },
+      }}
+    />
+  );
+}

--- a/src/pages/home/index.jsx
+++ b/src/pages/home/index.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { selectStudentId } from '../store/student/selectors';
-import { selectTeacherId } from '../store/teacher/selectors';
-import PolarChart from '../components/charts/PolarChart';
-import BarChart from '../components/charts/BarChart';
-import LineChart from '../components/charts/LineChart';
+import { selectStudentId } from '../../store/student/selectors';
+import { selectTeacherId } from '../../store/teacher/selectors';
+import BarChartHome from './BarChartHome';
+import LineChartHome from './LineChartHome';
+import PolarChartHome from './PolarChartHome';
 import { Layout, Row, Col } from 'antd';
 const { Content } = Layout;
 
@@ -35,7 +35,7 @@ export default function Home() {
           <Row justify="space-around">
             <Col>
               <div style={{ width: '35vw', height: '35vh' }}>
-                <BarChart
+                <BarChartHome
                   labels={['Welcome', 'to', 'your', 'dashboard']}
                   color={['#FF2694', '#FF2694', '#FF2694', '#FF2694']}
                   data={[80, 56, 67, 45]}
@@ -46,7 +46,7 @@ export default function Home() {
           <Row justify="space-around">
             <Col>
               <div style={{ width: '35vw', height: '35vh' }}>
-                <PolarChart
+                <PolarChartHome
                   labels={['Please', 'log', 'in']}
                   color={['#B81D9D', '#D222E1', '#8F1CB8']}
                   data={[80, 56, 67]}
@@ -55,7 +55,7 @@ export default function Home() {
             </Col>
             <Col>
               <div style={{ width: '35vw', height: '35vh' }}>
-                <LineChart
+                <LineChartHome
                   labels={['to', 'see', 'your', 'progress']}
                   color={['#A026FF']}
                   data={[45, 67, 56, 80]}

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -4,8 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
 import { getMcQuestionsForTest, submitTest } from '../../store/test/actions';
 import { select3mcQuestionsForSubject } from '../../store/test/selectors';
-import { Layout, Button, Row } from 'antd';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
+import { Layout, Button, Row } from 'antd';
 
 const { Content } = Layout;
 
@@ -35,7 +35,7 @@ export default function StudentDoTest() {
         answer3
       )
     );
-    history.push(`/students/${studentId}`);
+    history.push(`/students/${studentId}/subjects/${subjectid}`);
   };
 
   const onPick = (e) => {

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -75,12 +75,21 @@ export default function StudentSubjectDetails() {
   };
 
   const renderChart = () => {
+    const subject = subjects.find((subject) => subject.id === subjectid * 1)
+      .name;
     const data = results.map(({ result }) => result);
     const color = [];
     for (let i = 0; i < results.length; i++) color.push('rgb(255, 99, 132)');
     const labels = results.map(({ at }) => moment(at).format('MMM Do YY'));
 
-    return <BarChart data={data} color={color} labels={labels} />;
+    return (
+      <BarChart
+        data={data}
+        color={color}
+        labels={labels}
+        title={`RESULTS FOR YOUR ${subject.toUpperCase()} TESTS`}
+      />
+    );
   };
 
   return (
@@ -102,10 +111,9 @@ export default function StudentSubjectDetails() {
           <Row>
             <Col>
               <div style={{ width: '35vw', height: '35vh' }}>
-                {results[0] ? renderChart() : null}
+                {subjects && results[0] ? renderChart() : null}
               </div>
             </Col>
-            <Col>Extra</Col>
           </Row>
         </Content>
       </Layout>

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -10,7 +10,7 @@ import { getResultsForSubject } from '../../store/testResults/actions';
 import { selectResultsForSubject } from '../../store/testResults/selectors';
 import BarChart from '../../components/charts/BarChart';
 import DoughnutChart from '../../components/charts/DoughnutChart';
-import { Layout, Button, Row } from 'antd';
+import { Layout, Button, Row, Col } from 'antd';
 
 // import StudentSubjectChart from './StudentSubjectChart';
 const { Content } = Layout;
@@ -51,9 +51,16 @@ export default function StudentSubjectDetails() {
       .name;
     return (
       <>
+        <Row>
+          <h2>{subject.charAt(0).toUpperCase() + subject.slice(1)}</h2>
+        </Row>
         <Row>You have done</Row>
-        <Row>{results.length}</Row>
-        <Row>tests for {subject}</Row>
+        <Row>
+          <span style={{ fontSize: '3.3rem', fontWeight: 'bold' }}>
+            {results.length}
+          </span>
+        </Row>
+        <Row>tests so far</Row>
         <Row>
           <Button
             onClick={() =>
@@ -80,15 +87,26 @@ export default function StudentSubjectDetails() {
     <Layout>
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
-          <div style={{ width: '35vw', height: '35vh' }}>
-            {subjects && results[0] ? renderAmount() : null}
-          </div>
-          <div style={{ width: '35vw', height: '35vh' }}>
-            {results[0] ? renderChart() : null}
-          </div>
-          <div style={{ width: '35vw', height: '35vh' }}>
-            {results[0] ? renderAverage() : null}
-          </div>
+          <Row>
+            <Col>
+              <div style={{ width: '35vw', height: '35vh' }}>
+                {subjects && results[0] ? renderAmount() : null}
+              </div>
+            </Col>
+            <Col>
+              <div style={{ width: '35vw', height: '35vh' }}>
+                {results[0] ? renderAverage() : null}
+              </div>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <div style={{ width: '35vw', height: '35vh' }}>
+                {results[0] ? renderChart() : null}
+              </div>
+            </Col>
+            <Col>Extra</Col>
+          </Row>
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -9,6 +9,7 @@ import {
 import { getResultsForSubject } from '../../store/testResults/actions';
 import { selectResultsForSubject } from '../../store/testResults/selectors';
 import BarChart from '../../components/charts/BarChart';
+import DoughnutChart from '../../components/charts/DoughnutChart';
 import { Layout, Button, Row } from 'antd';
 
 // import StudentSubjectChart from './StudentSubjectChart';
@@ -35,7 +36,14 @@ export default function StudentSubjectDetails() {
     const average = Math.round(
       (data.reduce((a, b) => a + b, 0) / (data.length * 3)) * 100
     );
-    console.log(average);
+    const color = ['#A026FF', '#eee'];
+    return (
+      <DoughnutChart
+        color={color}
+        data={[average, 100 - average]}
+        title={`AVERAGE OF ${average}%`}
+      />
+    );
   };
 
   const renderAmount = () => {
@@ -74,7 +82,11 @@ export default function StudentSubjectDetails() {
         <Content className="site-layout-background">
           <div style={{ width: '35vw', height: '35vh' }}>
             {subjects && results[0] ? renderAmount() : null}
+          </div>
+          <div style={{ width: '35vw', height: '35vh' }}>
             {results[0] ? renderChart() : null}
+          </div>
+          <div style={{ width: '35vw', height: '35vh' }}>
             {results[0] ? renderAverage() : null}
           </div>
         </Content>

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import moment from 'moment';
 import { selectStudentId } from '../../store/student/selectors';
 import { getResultsForSubject } from '../../store/testResults/actions';
 import { selectResultsForSubject } from '../../store/testResults/selectors';
@@ -29,7 +30,8 @@ export default function StudentSubjectDetails() {
     const data = results.map(({ result }) => result);
     const color = [];
     for (let i = 0; i < results.length; i++) color.push('rgb(255, 99, 132)');
-    const labels = ['t1', 't2', 't3'];
+    const labels = results.map(({ at }) => moment(at).format('MMM Do YY'));
+
     return <BarChart data={data} color={color} labels={labels} />;
   };
 

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -2,7 +2,10 @@ import React, { useEffect } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import moment from 'moment';
-import { selectStudentId } from '../../store/student/selectors';
+import {
+  selectStudentId,
+  selectStudentSubjects,
+} from '../../store/student/selectors';
 import { getResultsForSubject } from '../../store/testResults/actions';
 import { selectResultsForSubject } from '../../store/testResults/selectors';
 import BarChart from '../../components/charts/BarChart';
@@ -13,10 +16,11 @@ const { Content } = Layout;
 
 export default function StudentSubjectDetails() {
   const dispatch = useDispatch();
-  const studentId = useSelector(selectStudentId);
-  const results = useSelector(selectResultsForSubject);
   const { subjectid } = useParams();
   const history = useHistory();
+  const studentId = useSelector(selectStudentId);
+  const results = useSelector(selectResultsForSubject);
+  const subjects = useSelector(selectStudentSubjects);
 
   const goTo = (goto) => {
     history.push(goto);
@@ -25,6 +29,18 @@ export default function StudentSubjectDetails() {
   useEffect(() => {
     dispatch(getResultsForSubject(subjectid));
   }, [dispatch, subjectid]);
+
+  const renderAmount = () => {
+    const subject = subjects.find((subject) => subject.id === subjectid * 1)
+      .name;
+    return (
+      <>
+        <Row>You have done</Row>
+        <Row>{results.length}</Row>
+        <Row>tests for {subject}</Row>
+      </>
+    );
+  };
 
   const renderChart = () => {
     const data = results.map(({ result }) => result);
@@ -50,6 +66,7 @@ export default function StudentSubjectDetails() {
             </Button>
           </Row>
           <div style={{ width: '35vw', height: '35vh' }}>
+            {subjects && results ? renderAmount() : null}
             {results ? renderChart() : null}
           </div>
         </Content>

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -3,6 +3,8 @@ import { useParams, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
 import { getResultsForSubject } from '../../store/testResults/actions';
+import { selectResultsForSubject } from '../../store/testResults/selectors';
+import BarChart from '../../components/charts/BarChart';
 import { Layout, Button, Row } from 'antd';
 
 // import StudentSubjectChart from './StudentSubjectChart';
@@ -11,6 +13,7 @@ const { Content } = Layout;
 export default function StudentSubjectDetails() {
   const dispatch = useDispatch();
   const studentId = useSelector(selectStudentId);
+  const results = useSelector(selectResultsForSubject);
   const { subjectid } = useParams();
   const history = useHistory();
 
@@ -21,6 +24,14 @@ export default function StudentSubjectDetails() {
   useEffect(() => {
     dispatch(getResultsForSubject(subjectid));
   }, [dispatch, subjectid]);
+
+  const renderChart = () => {
+    const data = results.map(({ result }) => result);
+    const color = [];
+    for (let i = 0; i < results.length; i++) color.push('rgb(255, 99, 132)');
+    const labels = ['t1', 't2', 't3'];
+    return <BarChart data={data} color={color} labels={labels} />;
+  };
 
   return (
     <Layout>
@@ -36,6 +47,9 @@ export default function StudentSubjectDetails() {
               Do a test
             </Button>
           </Row>
+          <div style={{ width: '35vw', height: '35vh' }}>
+            {results ? renderChart() : null}
+          </div>
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -30,6 +30,14 @@ export default function StudentSubjectDetails() {
     dispatch(getResultsForSubject(subjectid));
   }, [dispatch, subjectid]);
 
+  const renderAverage = () => {
+    const data = results.map(({ result }) => result);
+    const average = Math.round(
+      (data.reduce((a, b) => a + b, 0) / (data.length * 3)) * 100
+    );
+    console.log(average);
+  };
+
   const renderAmount = () => {
     const subject = subjects.find((subject) => subject.id === subjectid * 1)
       .name;
@@ -38,6 +46,15 @@ export default function StudentSubjectDetails() {
         <Row>You have done</Row>
         <Row>{results.length}</Row>
         <Row>tests for {subject}</Row>
+        <Row>
+          <Button
+            onClick={() =>
+              goTo(`/students/${studentId}/subjects/${subjectid}/test`)
+            }
+          >
+            Do a another test
+          </Button>
+        </Row>
       </>
     );
   };
@@ -55,19 +72,10 @@ export default function StudentSubjectDetails() {
     <Layout>
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
-          <Row> details for a subject for a student</Row>
-          <Row>
-            <Button
-              onClick={() =>
-                goTo(`/students/${studentId}/subjects/${subjectid}/test`)
-              }
-            >
-              Do a test
-            </Button>
-          </Row>
           <div style={{ width: '35vw', height: '35vh' }}>
-            {subjects && results ? renderAmount() : null}
-            {results ? renderChart() : null}
+            {subjects && results[0] ? renderAmount() : null}
+            {results[0] ? renderChart() : null}
+            {results[0] ? renderAverage() : null}
           </div>
         </Content>
       </Layout>

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { selectStudentId } from '../../store/student/selectors';
+import { getResultsForSubject } from '../../store/testResults/actions';
 import { Layout, Button, Row } from 'antd';
 
 // import StudentSubjectChart from './StudentSubjectChart';
 const { Content } = Layout;
 
 export default function StudentSubjectDetails() {
+  const dispatch = useDispatch();
   const studentId = useSelector(selectStudentId);
   const { subjectid } = useParams();
   const history = useHistory();
@@ -15,6 +17,10 @@ export default function StudentSubjectDetails() {
   const goTo = (goto) => {
     history.push(goto);
   };
+
+  useEffect(() => {
+    dispatch(getResultsForSubject(subjectid));
+  }, [dispatch, subjectid]);
 
   return (
     <Layout>

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -5,6 +5,7 @@ import student from './student/reducer';
 import teacher from './teacher/reducer';
 import questions from './questions/reducer';
 import test from './test/reducer';
+import testResults from './testResults/reducer';
 
 export default combineReducers({
   appState,
@@ -13,4 +14,5 @@ export default combineReducers({
   teacher,
   questions,
   test,
+  testResults,
 });

--- a/src/store/testResults/actions.js
+++ b/src/store/testResults/actions.js
@@ -1,0 +1,37 @@
+import axios from 'axios';
+import { apiUrl } from '../../config/constants';
+import { appLoading, appDoneLoading, setMessage } from '../appState/actions';
+
+export const FETCH_RESULTS_FOR_SUBJECT = 'FETCH_RESULTS_FOR_SUBJECT';
+
+export function resultsFetched(questions) {
+  return {
+    type: FETCH_RESULTS_FOR_SUBJECT,
+    payload: questions,
+  };
+}
+
+export function getResultsForSubject(id) {
+  return async function thunk(dispatch, getState) {
+    const token = getState().student.token;
+    dispatch(appLoading());
+    try {
+      const response = await axios.get(`${apiUrl}/data/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const questions = response.data;
+
+      dispatch(resultsFetched(questions));
+      dispatch(appDoneLoading());
+    } catch (error) {
+      if (error.response) {
+        console.log(error.response.data.message);
+        dispatch(setMessage('danger', true, error.response.data.message));
+      } else {
+        console.log(error.message);
+        dispatch(setMessage('danger', true, error.message));
+      }
+      dispatch(appDoneLoading());
+    }
+  };
+}

--- a/src/store/testResults/reducer.js
+++ b/src/store/testResults/reducer.js
@@ -1,0 +1,14 @@
+import { FETCH_RESULTS_FOR_SUBJECT } from './actions';
+
+const initialState = {
+  all: [],
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_RESULTS_FOR_SUBJECT:
+      return { ...state, all: action.payload };
+    default:
+      return state;
+  }
+};

--- a/src/store/testResults/selectors.js
+++ b/src/store/testResults/selectors.js
@@ -1,3 +1,3 @@
-export const selectAllQuestionsForSubject = (state) => {
+export const selectResultsForSubject = (state) => {
   return state.testResults.all;
 };

--- a/src/store/testResults/selectors.js
+++ b/src/store/testResults/selectors.js
@@ -1,0 +1,3 @@
+export const selectAllQuestionsForSubject = (state) => {
+  return state.testResults.all;
+};


### PR DESCRIPTION
Exciting section of the project. In this section I visualize the data from the tests.

The data available from the back is:
- studentId
- subjectId
- question 1, 2, 3
- answer 1, 2, 3 

The backend returns every test for subjectId and subjectId, with the use of authMiddlware.
The back sums the answers, as they are 1 or 0, returns the sum as result.

The front receives for each test the date and the result.
The front calculates the average.

The charts-components are fed dynamically with props.

There was one big reorganization. The homepage uses charts as well, but as the set up for details is radically different, I decided to create a Home folder in the pages folder, and add the charts for the homepage there - instead of using the components.

To do:
Have a look at the Redux store. Now, after finishing the test, it fetches the data again to update the charts.  Depending on the calculations done in the back, this might not be necessary. 

<img width="741" alt="Schermafbeelding 2020-07-02 om 09 05 36" src="https://user-images.githubusercontent.com/60842970/86327230-366a7a80-bc43-11ea-90cf-fa3086218a30.png">

