### PR TITLE
Feat prevent leaving

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Layout } from 'antd';
 import BarAtTheTop from './components/BarAtThetop';
 import AlertBox from './components/AlertBox';
-// import Spinner from './components/Spinner';
+import Spinner from './components/Spinner';
 import Sidebar from './components/Sidebar';
 import Home from './pages/home/';
 import Login from './pages/Login';
@@ -17,7 +17,7 @@ import TeacherStudentDetails from './pages/teacher/TeacherStudentDetails';
 import TeacherSubjectDetails from './pages/teacher/TeacherSubjectDetails';
 import AddQuestionForm from './pages/teacher/AddQuestionForm';
 import ListOfQuestions from './pages/teacher/ListOfQuestions';
-// import { selectAppLoading } from './store/appState/selectors';
+import { selectAppLoading } from './store/appState/selectors';
 import { selectTeacherToken } from './store/teacher/selectors';
 import { getStudentWithStoredToken } from './store/student/actions';
 import { getTeacherWithStoredToken } from './store/teacher/actions';
@@ -26,7 +26,7 @@ import './App.css';
 
 function App() {
   const dispatch = useDispatch();
-  // const isLoading = useSelector(selectAppLoading);
+  const isLoading = useSelector(selectAppLoading);
   const teacherToken = useSelector(selectTeacherToken);
 
   useEffect(() => {
@@ -43,7 +43,7 @@ function App() {
       <AlertBox />
       <Layout>
         <Sidebar />
-        {/* {isLoading ? <Spinner /> : null} */}
+        {isLoading ? <Spinner /> : null}
         <Switch>
           <Route exact path="/" component={Home} />
           <Route exact path="/login" component={Login} />

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useHistory, Prompt } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import MultipleChoiceQuestion from '../../components/MultipleChoiceQuestion';
 import {
@@ -29,6 +29,7 @@ export default function StudentDoTest() {
   const [question2, setQuestion2] = useState(0);
   const [question3, setQuestion3] = useState(0);
   const [testDone, setTestDone] = useState(false);
+  const [blockNavigation, setBlockNavigation] = useState(true);
 
   useEffect(() => {
     if (token === null) {
@@ -57,6 +58,7 @@ export default function StudentDoTest() {
     setAnswer1(0);
     setAnswer2(0);
     setAnswer3(0);
+    setBlockNavigation(false);
   };
 
   const goToMain = () => {
@@ -64,6 +66,7 @@ export default function StudentDoTest() {
   };
 
   const doAnotherTest = () => {
+    setBlockNavigation(true);
     setTestDone(false);
     dispatch(getMcQuestionsForTest(subjectid));
   };
@@ -99,6 +102,10 @@ export default function StudentDoTest() {
 
   return (
     <Layout>
+      <Prompt
+        when={blockNavigation}
+        message="You have not finished you test, are you sure you want to leave?"
+      />
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
           {questions && subjects ? renderMCQ() : null}

--- a/src/pages/student/StudentDoTest.jsx
+++ b/src/pages/student/StudentDoTest.jsx
@@ -96,6 +96,47 @@ export default function StudentDoTest() {
             questionNumber={i + 1}
           />
         ))}
+        {!testDone ? (
+          <Button
+            style={{
+              width: 160,
+              backgroundColor: '#B81D9D',
+              border: 'none',
+              color: '#fff',
+            }}
+            onClick={onFinish}
+          >
+            Finish
+          </Button>
+        ) : null}
+        {testDone ? (
+          <>
+            <p>{'You want to take another test?'.toUpperCase()}</p>
+            <Button
+              style={{
+                width: 160,
+                backgroundColor: '#4BC0E7',
+                border: 'none',
+                color: '#fff',
+                marginRight: 20,
+              }}
+              onClick={doAnotherTest}
+            >
+              yes
+            </Button>
+            <Button
+              style={{
+                width: 160,
+                backgroundColor: '#B81D9D',
+                border: 'none',
+                color: '#fff',
+              }}
+              onClick={goToMain}
+            >
+              no
+            </Button>
+          </>
+        ) : null}
       </>
     );
   };
@@ -105,51 +146,11 @@ export default function StudentDoTest() {
       <Prompt
         when={blockNavigation}
         message="You have not finished you test, are you sure you want to leave?"
+        onCancel={() => console.log('ok')}
       />
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
           {questions && subjects ? renderMCQ() : null}
-          {!testDone ? (
-            <Button
-              style={{
-                width: 160,
-                backgroundColor: '#B81D9D',
-                border: 'none',
-                color: '#fff',
-              }}
-              onClick={onFinish}
-            >
-              Finish
-            </Button>
-          ) : null}
-          {testDone ? (
-            <>
-              <p>{'You want to take another test?'.toUpperCase()}</p>
-              <Button
-                style={{
-                  width: 160,
-                  backgroundColor: '#4BC0E7',
-                  border: 'none',
-                  color: '#fff',
-                  marginRight: 20,
-                }}
-                onClick={doAnotherTest}
-              >
-                yes
-              </Button>
-              <Button
-                style={{
-                  width: 160,
-                  backgroundColor: '#B81D9D',
-                  border: 'none',
-                  color: '#fff',
-                }}
-                onClick={goToMain}
-              >
-                no
-              </Button>
-            </>
-          ) : null}
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/student/StudentMainPage.jsx
+++ b/src/pages/student/StudentMainPage.jsx
@@ -43,7 +43,7 @@ export default function StudentMainPage() {
       )
     );
 
-    return (
+    return results[0] ? (
       <>
         <Row justify="space-around">
           <Col style={{ width: 450, paddingBottom: 80 }}>
@@ -57,6 +57,8 @@ export default function StudentMainPage() {
           <Col style={{ width: 650 }}>{renderPolar(subjectSorted)}</Col>
         </Row>
       </>
+    ) : (
+      <>No data yet</>
     );
   };
 
@@ -64,17 +66,13 @@ export default function StudentMainPage() {
     const generalScore = Math.round(
       averages.reduce((a, b) => a + b * 1, 0) / averages.length
     );
-    if (!generalScore) {
-      return <div>You have no general score yet</div>;
-    } else {
-      return (
-        <DoughnutChart
-          data={[generalScore, 100 - generalScore]}
-          color={['#8F1CB8', '#eee']}
-          title={`YOUR HAVE A GENERAL SCORE OF ${generalScore}%`}
-        />
-      );
-    }
+    return (
+      <DoughnutChart
+        data={[generalScore, 100 - generalScore]}
+        color={['#8F1CB8', '#eee']}
+        title={`YOUR HAVE A GENERAL SCORE OF ${generalScore}%`}
+      />
+    );
   };
 
   const renderAveragePerSubject = (averages) => {

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -76,21 +76,6 @@ export default function StudentSubjectDetails() {
     );
   };
 
-  const renderNoTestsYet = () => {
-    return (
-      <Col>
-        <h2>No results yet.</h2>
-        <Button
-          onClick={() =>
-            goTo(`/students/${studentId}/subjects/${subjectid}/test`)
-          }
-        >
-          Do a test
-        </Button>
-      </Col>
-    );
-  };
-
   const renderTestButton = () => {
     return (
       <Col
@@ -146,9 +131,9 @@ export default function StudentSubjectDetails() {
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
           <Row justify="space-around">
-            {subjects && results ? renderAmount() : renderNoTestsYet()}
-            {results ? renderAverage() : null}
-            {renderTestButton()}
+            {subjects && results ? renderAmount() : null}
+            {subjects && results ? renderAverage() : null}
+            {subjects && results ? renderTestButton() : null}
           </Row>
           <Row justify="center">
             {subjects && results ? renderBarChart() : null}


### PR DESCRIPTION
When the student leaves halfway a test he/she well get a pop up message and will have to confirm he/she wants to leave.

I have re-activated the spinner (loader). I added a small delay to the back-end, to create a more realistic timing. It makes the dashboard less snappy. I could have chosen to fetch everything via the student main page, in one bigger store and get the details for the subjects from there. Seeing the charts reacting very quickly to that data is nice, but as there is normally a lot more data than I have now, having all that data fetched at once and stored in one mega-store is not a perfect situation. Thus for the details page the data is fetched separately, that means you will see a spinner.

I cleaned up the dashboard for a new student, so he/she isn't bother with empty charts.