### PR TITLE
Feat filter sort

### DIFF
--- a/src/components/SortAndSelect.jsx
+++ b/src/components/SortAndSelect.jsx
@@ -11,7 +11,7 @@ export default function SortAndSelect({
   value,
   onChangeSelection,
   results,
-  selectStudentAverage,
+  selectStudentData,
   onClick,
   placeholder,
   textBtn,
@@ -44,7 +44,7 @@ export default function SortAndSelect({
           </Option>
         ))}
       </Select>
-      {selectStudentAverage ? (
+      {selectStudentData ? (
         <Button size="small" onClick={onClick}>
           {textBtn}
         </Button>

--- a/src/components/SortAndSelect.jsx
+++ b/src/components/SortAndSelect.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Row, Radio, Select, Button } from 'antd';
+
+const { Option } = Select;
+
+export default function SortAndSelect({
+  title,
+  radio1,
+  radio2,
+  onChangeRadio,
+  value,
+  onChangeSelection,
+  results,
+  selectStudentAverage,
+  onClick,
+}) {
+  return (
+    <Row style={{ paddingBottom: 35 }}>
+      {title}
+      <Radio.Group
+        size="small"
+        style={{ marginLeft: 40 }}
+        onChange={(e) => onChangeRadio(e.target.value)}
+      >
+        <Radio.Button value={radio1.toLowerCase()}>{radio1}</Radio.Button>
+        <Radio.Button value={radio2.toLowerCase()}>{radio2}</Radio.Button>
+      </Radio.Group>
+      <Select
+        size="small"
+        style={{ width: 160 }}
+        placeholder="Select a student"
+        value={value}
+        onChange={(e) => onChangeSelection(e)}
+      >
+        {results.map(({ name }, i) => (
+          <Option key={i} value={name}>
+            {name}
+          </Option>
+        ))}
+      </Select>
+      {selectStudentAverage ? (
+        <Button size="small" onClick={onClick}>
+          All students
+        </Button>
+      ) : null}
+    </Row>
+  );
+}

--- a/src/components/SortAndSelect.jsx
+++ b/src/components/SortAndSelect.jsx
@@ -13,6 +13,8 @@ export default function SortAndSelect({
   results,
   selectStudentAverage,
   onClick,
+  placeholder,
+  textBtn,
 }) {
   return (
     <Row style={{ paddingBottom: 35 }}>
@@ -22,13 +24,17 @@ export default function SortAndSelect({
         style={{ marginLeft: 40 }}
         onChange={(e) => onChangeRadio(e.target.value)}
       >
-        <Radio.Button value={radio1.toLowerCase()}>{radio1}</Radio.Button>
-        <Radio.Button value={radio2.toLowerCase()}>{radio2}</Radio.Button>
+        <Radio.Button style={{ marginRight: 5 }} value={radio1.toLowerCase()}>
+          {radio1}
+        </Radio.Button>
+        <Radio.Button style={{ marginRight: 5 }} value={radio2.toLowerCase()}>
+          {radio2}
+        </Radio.Button>
       </Radio.Group>
       <Select
         size="small"
-        style={{ width: 160 }}
-        placeholder="Select a student"
+        style={{ width: 160, marginRight: 5 }}
+        placeholder={placeholder}
         value={value}
         onChange={(e) => onChangeSelection(e)}
       >
@@ -40,7 +46,7 @@ export default function SortAndSelect({
       </Select>
       {selectStudentAverage ? (
         <Button size="small" onClick={onClick}>
-          All students
+          {textBtn}
         </Button>
       ) : null}
     </Row>

--- a/src/pages/student/StudentMainPage.jsx
+++ b/src/pages/student/StudentMainPage.jsx
@@ -72,7 +72,9 @@ export default function StudentMainPage() {
         color={['#8F1CB8', '#eee']}
         title={`YOUR HAVE A GENERAL SCORE OF ${generalScore}%`}
       />
-    ) : null;
+    ) : (
+      <p>YOU DON'T HAVE ENOUGH DATA YET TO DISPLAY AVERAGE</p>
+    );
   };
 
   const renderAveragePerSubject = (averages) => {

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -136,7 +136,7 @@ export default function StudentSubjectDetails() {
               Scores Low to High
             </Radio.Button>
             <Radio.Button style={{ marginRight: 5 }} value="highestFirst">
-              Scores Low to High
+              Scores High to Low
             </Radio.Button>
           </Radio.Group>
         </Row>

--- a/src/pages/teacher/TeacherMainPage.jsx
+++ b/src/pages/teacher/TeacherMainPage.jsx
@@ -55,7 +55,7 @@ export default function TeacherMainPage() {
         />
       </Col>
     ) : (
-      <p>YOU HAVE NO DATA TO DISPLAY YET</p>
+      <p>YOU DON'T HAVE ENOUGH DATA YET TO DISPLAY AVERAGE</p>
     );
   };
 
@@ -110,7 +110,7 @@ export default function TeacherMainPage() {
       }, {});
     const data = Object.values(reducedTests);
 
-    return data[0] ? (
+    return !data[0] ? null : data.length > 3 ? (
       <Col style={{ width: 450, paddingBottom: 80 }}>
         <PieChart
           data={data}
@@ -119,7 +119,9 @@ export default function TeacherMainPage() {
           labels={['0/3', '1/3', '2/3', '3/3']}
         />
       </Col>
-    ) : null;
+    ) : (
+      <p>YOU DON'T HAVE ENOUGH DATA YET TO DISPLAY TEST RATIO</p>
+    );
   };
 
   return (

--- a/src/pages/teacher/TeacherStudentDetails.jsx
+++ b/src/pages/teacher/TeacherStudentDetails.jsx
@@ -1,14 +1,16 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import DoughnutChart from '../../components/charts/DoughnutChart';
+import BarChartTest from '../../components/charts/BarChartTest';
+import SortAndSelect from '../../components/SortAndSelect';
 import { getStudentForOverview } from '../../store/overviewTeacher/actions';
 import { selectStudentOverview } from '../../store/overviewTeacher/selectors';
 import {
   selectTeacherSubjects,
   selectTeacherToken,
 } from '../../store/teacher/selectors';
-import DoughnutChart from '../../components/charts/DoughnutChart';
-import BarChartTest from '../../components/charts/BarChartTest';
+
 import { Layout, Row, Col } from 'antd';
 const { Content } = Layout;
 
@@ -19,6 +21,10 @@ export default function TeacherStudentDetails() {
   const { studentid } = useParams();
   const results = useSelector(selectStudentOverview);
   const subjects = useSelector(selectTeacherSubjects);
+  const [selectionAverage, setSelectionAverage] = useState('name');
+  const [selectionTests, setSelectionTests] = useState('name');
+  const [selectSubjectAverage, setSelectSubjectAverage] = useState('');
+  const [selectSubjectTests, setSelectSubjectTests] = useState('');
 
   useEffect(() => {
     if (token === null) {
@@ -31,14 +37,21 @@ export default function TeacherStudentDetails() {
   }, [dispatch, studentid]);
 
   const renderCharts = () => {
-    return results.map(({ score, subjectId }, i) => (
+    const sortedResults =
+      selectionAverage === 'name'
+        ? [...results].sort((a, b) => a.name.localeCompare(b.name))
+        : [...results].sort((a, b) => b.score - a.score);
+
+    const filteredResults = selectSubjectAverage
+      ? sortedResults.filter((result) => result.name === selectSubjectAverage)
+      : sortedResults;
+
+    return filteredResults.map(({ score, name }, i) => (
       <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
         <DoughnutChart
           data={[score, 100 - score]}
           color={['#8F1CB8', '#eee']}
-          title={`${
-            subjects.find((subject) => subject.id === subjectId).name
-          } ${score}%`}
+          title={`${name} ${score}%`}
         />
       </Col>
     ));
@@ -65,7 +78,21 @@ export default function TeacherStudentDetails() {
     <Layout>
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
-          <Row style={{ paddingBottom: 35 }}>AVERAGE GRADES</Row>
+          {results ? (
+            <SortAndSelect
+              title="AVERAGE GRADES"
+              radio1="Name"
+              radio2="Average"
+              onChangeRadio={setSelectionAverage}
+              value={selectSubjectAverage || undefined}
+              onChangeSelection={setSelectSubjectAverage}
+              results={results}
+              selectStudentAverage={selectSubjectAverage}
+              onClick={() => setSelectSubjectAverage('')}
+              placeholder="Select a subject"
+              textBtn="All subjects"
+            />
+          ) : null}
           <Row justify={'space-around'}>
             {results && subjects ? renderCharts() : null}
           </Row>

--- a/src/pages/teacher/TeacherStudentDetails.jsx
+++ b/src/pages/teacher/TeacherStudentDetails.jsx
@@ -58,16 +58,21 @@ export default function TeacherStudentDetails() {
   };
 
   const renderTestsBar = () => {
-    return results.map(({ tests, subjectId }, i) => (
+    const sortedResults =
+      selectionTests === 'name'
+        ? [...results].sort((a, b) => a.name.localeCompare(b.name))
+        : [...results].sort((a, b) => b.tests - a.tests);
+
+    const filteredResults = selectSubjectTests
+      ? sortedResults.filter((result) => result.name === selectSubjectTests)
+      : sortedResults;
+
+    return filteredResults.map(({ tests, name }, i) => (
       <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
         <BarChartTest
           data={[tests]}
           color={['#8F1CB8']}
-          labels={[
-            `${
-              subjects.find((subject) => subject.id === subjectId).name
-            }: ${tests} tests`,
-          ]}
+          labels={[`${name}: ${tests} tests`]}
           title={``}
         />
       </Col>
@@ -87,7 +92,7 @@ export default function TeacherStudentDetails() {
               value={selectSubjectAverage || undefined}
               onChangeSelection={setSelectSubjectAverage}
               results={results}
-              selectStudentAverage={selectSubjectAverage}
+              selectStudentData={selectSubjectAverage}
               onClick={() => setSelectSubjectAverage('')}
               placeholder="Select a subject"
               textBtn="All subjects"
@@ -96,7 +101,21 @@ export default function TeacherStudentDetails() {
           <Row justify={'space-around'}>
             {results && subjects ? renderCharts() : null}
           </Row>
-          <Row style={{ paddingBottom: 35 }}>TESTS DONE</Row>
+          {results ? (
+            <SortAndSelect
+              title="TESTS DONE"
+              radio1="Name"
+              radio2="Amount"
+              onChangeRadio={setSelectionTests}
+              value={selectSubjectTests || undefined}
+              onChangeSelection={setSelectSubjectTests}
+              results={results}
+              selectStudentData={selectSubjectTests}
+              onClick={() => setSelectSubjectTests('')}
+              placeholder="Select a subject"
+              textBtn="All subjects"
+            />
+          ) : null}
           <Row justify={'space-around'}>
             {results && subjects ? renderTestsBar() : null}
           </Row>

--- a/src/pages/teacher/TeacherSubjectDetails.jsx
+++ b/src/pages/teacher/TeacherSubjectDetails.jsx
@@ -1,18 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import DoughnutChart from '../../components/charts/DoughnutChart';
+import BarChartTest from '../../components/charts/BarChartTest';
+import SortAndSelect from '../../components/SortAndSelect';
 import { getSubjectForOverview } from '../../store/overviewTeacher/actions';
 import { selectSubjectOverview } from '../../store/overviewTeacher/selectors';
 import {
   selectTeacherStudents,
   selectTeacherToken,
 } from '../../store/teacher/selectors';
-import DoughnutChart from '../../components/charts/DoughnutChart';
-import BarChartTest from '../../components/charts/BarChartTest';
-import { Layout, Row, Col, Radio, Select, Button } from 'antd';
+
+import { Layout, Row, Col, Radio } from 'antd';
 
 const { Content } = Layout;
-const { Option } = Select;
 
 export default function TeacherSubjectDetails() {
   const dispatch = useDispatch();
@@ -24,6 +25,7 @@ export default function TeacherSubjectDetails() {
   const [selectionAverage, setSelectionAverage] = useState('name');
   const [selectionTests, setSelectionTests] = useState('name');
   const [selectStudentAverage, setSelectStudentAverage] = useState('');
+  const [selectStudentTests, setSelectStudentTests] = useState('');
 
   useEffect(() => {
     if (token === null) {
@@ -40,6 +42,7 @@ export default function TeacherSubjectDetails() {
       selectionAverage === 'name'
         ? [...results].sort((a, b) => a.name.localeCompare(b.name))
         : [...results].sort((a, b) => b.score - a.score);
+
     const filteredResults = selectStudentAverage
       ? sortedResults.filter((result) => result.name === selectStudentAverage)
       : sortedResults;
@@ -61,7 +64,11 @@ export default function TeacherSubjectDetails() {
         ? [...results].sort((a, b) => a.name.localeCompare(b.name))
         : [...results].sort((a, b) => b.tests - a.tests);
 
-    return sortedResults.map(({ tests, name }, i) => (
+    const filteredResults = selectStudentTests
+      ? sortedResults.filter((result) => result.name === selectStudentTests)
+      : sortedResults;
+
+    return filteredResults.map(({ tests, name }, i) => (
       <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
         <BarChartTest
           data={[tests]}
@@ -78,54 +85,35 @@ export default function TeacherSubjectDetails() {
     <Layout>
       <Layout style={{ padding: '24px', minHeight: '92vh' }}>
         <Content className="site-layout-background">
-          <Row style={{ paddingBottom: 35 }}>
-            AVERAGE GRADES
-            <Radio.Group
-              size="small"
-              onChange={(e) => setSelectionAverage(e.target.value)}
-              defaultValue="name"
-              style={{ marginLeft: 40 }}
-            >
-              <Radio.Button value="name">Name</Radio.Button>
-              <Radio.Button value="average">Average</Radio.Button>
-            </Radio.Group>
-            {results ? (
-              <Select
-                size="small"
-                style={{ width: 160 }}
-                placeholder="Select a student"
-                value={selectStudentAverage || undefined}
-                onChange={(e) => setSelectStudentAverage(e)}
-              >
-                {results.map(({ name }, i) => (
-                  <Option key={i} value={name}>
-                    {name}
-                  </Option>
-                ))}
-              </Select>
-            ) : null}
-            {selectStudentAverage ? (
-              <Button size="small" onClick={() => setSelectStudentAverage('')}>
-                All students
-              </Button>
-            ) : null}
-          </Row>
-
+          {results ? (
+            <SortAndSelect
+              title="AVERAGE GRADES"
+              radio1="Name"
+              radio2="Average"
+              onChangeRadio={setSelectionAverage}
+              value={selectStudentAverage || undefined}
+              onChangeSelection={setSelectStudentAverage}
+              results={results}
+              selectStudentAverage={selectStudentAverage}
+              onClick={() => setSelectStudentAverage('')}
+            />
+          ) : null}
           <Row justify={'space-around'}>
             {results && students ? renderCharts() : null}
           </Row>
-          <Row style={{ paddingBottom: 35 }}>
-            TESTS DONE{' '}
-            <Radio.Group
-              size="small"
-              onChange={(e) => setSelectionTests(e.target.value)}
-              defaultValue="name"
-              style={{ marginLeft: 40 }}
-            >
-              <Radio.Button value="name">Name</Radio.Button>
-              <Radio.Button value="amount">Amount of Tests</Radio.Button>
-            </Radio.Group>
-          </Row>
+          {results ? (
+            <SortAndSelect
+              title="TESTS DONE"
+              radio1="Name"
+              radio2="Amount"
+              onChangeRadio={setSelectionTests}
+              value={selectStudentTests || undefined}
+              onChangeSelection={setSelectStudentTests}
+              results={results}
+              selectStudentAverage={selectStudentTests}
+              onClick={() => setSelectStudentTests('')}
+            />
+          ) : null}
           <Row justify={'space-around'}>
             {results && students ? renderTestsBar() : null}
           </Row>

--- a/src/pages/teacher/TeacherSubjectDetails.jsx
+++ b/src/pages/teacher/TeacherSubjectDetails.jsx
@@ -20,6 +20,7 @@ export default function TeacherSubjectDetails() {
   const results = useSelector(selectSubjectOverview);
   const students = useSelector(selectTeacherStudents);
   const [selectionAverage, setSelectionAverage] = useState('name');
+  const [selectionTests, setSelectionTests] = useState('name');
 
   useEffect(() => {
     if (token === null) {
@@ -32,36 +33,29 @@ export default function TeacherSubjectDetails() {
   }, [dispatch, subjectid]);
 
   const renderCharts = () => {
-    if (selectionAverage === 'name') {
-      console.log('sort by name');
-      return [...results]
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(({ score, name }, i) => (
-          <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
-            <DoughnutChart
-              data={[score, 100 - score]}
-              color={['#008080', '#eee']}
-              title={`${name} ${score}%`}
-            />
-          </Col>
-        ));
-    } else {
-      return [...results]
-        .sort((a, b) => b.score - a.score)
-        .map(({ score, name }, i) => (
-          <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
-            <DoughnutChart
-              data={[score, 100 - score]}
-              color={['#008080', '#eee']}
-              title={`${name} ${score}%`}
-            />
-          </Col>
-        ));
-    }
+    const sortedResults =
+      selectionAverage === 'name'
+        ? [...results].sort((a, b) => a.name.localeCompare(b.name))
+        : [...results].sort((a, b) => b.score - a.score);
+
+    return sortedResults.map(({ score, name }, i) => (
+      <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
+        <DoughnutChart
+          data={[score, 100 - score]}
+          color={['#008080', '#eee']}
+          title={`${name} ${score}%`}
+        />
+      </Col>
+    ));
   };
 
   const renderTestsBar = () => {
-    return results.map(({ tests, name }, i) => (
+    const sortedResults =
+      selectionTests === 'name'
+        ? [...results].sort((a, b) => a.name.localeCompare(b.name))
+        : [...results].sort((a, b) => b.tests - a.tests);
+
+    return sortedResults.map(({ tests, name }, i) => (
       <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
         <BarChartTest
           data={[tests]}
@@ -94,7 +88,18 @@ export default function TeacherSubjectDetails() {
           <Row justify={'space-around'}>
             {results && students ? renderCharts() : null}
           </Row>
-          <Row style={{ paddingBottom: 35 }}>TESTS DONE</Row>
+          <Row style={{ paddingBottom: 35 }}>
+            TESTS DONE{' '}
+            <Radio.Group
+              size="small"
+              onChange={(e) => setSelectionTests(e.target.value)}
+              defaultValue="name"
+              style={{ marginLeft: 40 }}
+            >
+              <Radio.Button value="name">Name</Radio.Button>
+              <Radio.Button value="amount">Amount of Tests</Radio.Button>
+            </Radio.Group>
+          </Row>
           <Row justify={'space-around'}>
             {results && students ? renderTestsBar() : null}
           </Row>

--- a/src/pages/teacher/TeacherSubjectDetails.jsx
+++ b/src/pages/teacher/TeacherSubjectDetails.jsx
@@ -9,8 +9,10 @@ import {
 } from '../../store/teacher/selectors';
 import DoughnutChart from '../../components/charts/DoughnutChart';
 import BarChartTest from '../../components/charts/BarChartTest';
-import { Layout, Row, Col, Radio } from 'antd';
+import { Layout, Row, Col, Radio, Select, Button } from 'antd';
+
 const { Content } = Layout;
+const { Option } = Select;
 
 export default function TeacherSubjectDetails() {
   const dispatch = useDispatch();
@@ -21,6 +23,7 @@ export default function TeacherSubjectDetails() {
   const students = useSelector(selectTeacherStudents);
   const [selectionAverage, setSelectionAverage] = useState('name');
   const [selectionTests, setSelectionTests] = useState('name');
+  const [selectStudentAverage, setSelectStudentAverage] = useState('');
 
   useEffect(() => {
     if (token === null) {
@@ -37,8 +40,11 @@ export default function TeacherSubjectDetails() {
       selectionAverage === 'name'
         ? [...results].sort((a, b) => a.name.localeCompare(b.name))
         : [...results].sort((a, b) => b.score - a.score);
+    const filteredResults = selectStudentAverage
+      ? sortedResults.filter((result) => result.name === selectStudentAverage)
+      : sortedResults;
 
-    return sortedResults.map(({ score, name }, i) => (
+    return filteredResults.map(({ score, name }, i) => (
       <Col key={i} style={{ width: 350, paddingBottom: 80 }}>
         <DoughnutChart
           data={[score, 100 - score]}
@@ -83,6 +89,26 @@ export default function TeacherSubjectDetails() {
               <Radio.Button value="name">Name</Radio.Button>
               <Radio.Button value="average">Average</Radio.Button>
             </Radio.Group>
+            {results ? (
+              <Select
+                size="small"
+                style={{ width: 160 }}
+                placeholder="Select a student"
+                value={selectStudentAverage || undefined}
+                onChange={(e) => setSelectStudentAverage(e)}
+              >
+                {results.map(({ name }, i) => (
+                  <Option key={i} value={name}>
+                    {name}
+                  </Option>
+                ))}
+              </Select>
+            ) : null}
+            {selectStudentAverage ? (
+              <Button size="small" onClick={() => setSelectStudentAverage('')}>
+                All students
+              </Button>
+            ) : null}
           </Row>
 
           <Row justify={'space-around'}>

--- a/src/pages/teacher/TeacherSubjectDetails.jsx
+++ b/src/pages/teacher/TeacherSubjectDetails.jsx
@@ -94,7 +94,7 @@ export default function TeacherSubjectDetails() {
               value={selectStudentAverage || undefined}
               onChangeSelection={setSelectStudentAverage}
               results={results}
-              selectStudentAverage={selectStudentAverage}
+              selectStudentData={selectStudentAverage}
               onClick={() => setSelectStudentAverage('')}
               placeholder="Select a student"
               textBtn="All students"
@@ -112,7 +112,7 @@ export default function TeacherSubjectDetails() {
               value={selectStudentTests || undefined}
               onChangeSelection={setSelectStudentTests}
               results={results}
-              selectStudentAverage={selectStudentTests}
+              selectStudentData={selectStudentTests}
               onClick={() => setSelectStudentTests('')}
               placeholder="Select a student"
               textBtn="All students"

--- a/src/pages/teacher/TeacherSubjectDetails.jsx
+++ b/src/pages/teacher/TeacherSubjectDetails.jsx
@@ -11,7 +11,7 @@ import {
   selectTeacherToken,
 } from '../../store/teacher/selectors';
 
-import { Layout, Row, Col, Radio } from 'antd';
+import { Layout, Row, Col } from 'antd';
 
 const { Content } = Layout;
 
@@ -96,6 +96,8 @@ export default function TeacherSubjectDetails() {
               results={results}
               selectStudentAverage={selectStudentAverage}
               onClick={() => setSelectStudentAverage('')}
+              placeholder="Select a student"
+              textBtn="All students"
             />
           ) : null}
           <Row justify={'space-around'}>
@@ -112,6 +114,8 @@ export default function TeacherSubjectDetails() {
               results={results}
               selectStudentAverage={selectStudentTests}
               onClick={() => setSelectStudentTests('')}
+              placeholder="Select a student"
+              textBtn="All students"
             />
           ) : null}
           <Row justify={'space-around'}>


### PR DESCRIPTION
As I had some extra time I worked on the bonus features.
That is, filter and sort options to organize the different charts.

- When teachers zoom in on a student, they can order by subject name, subject average/amount of tests or filter out one subject. 

- When teachers zoom in on a subject, they can order by student name, student average/amount of tests or filter out a student.

- When a students zooms in on a subject he/she can sort the bar chart with test results:
1. from high to low
2. from low to high
3. by date

<img width="1061" alt="Schermafbeelding 2020-07-07 om 10 20 49" src="https://user-images.githubusercontent.com/60842970/86747351-f8eb6000-c03b-11ea-876b-2592d5588dbb.png">
<img width="951" alt="Schermafbeelding 2020-07-07 om 10 23 36" src="https://user-images.githubusercontent.com/60842970/86747367-fbe65080-c03b-11ea-9134-076e9f2d1b79.png">

