### PR TITLE
Feat add subject

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,10 +17,10 @@ import TeacherStudentDetails from './pages/teacher/TeacherStudentDetails';
 import TeacherSubjectDetails from './pages/teacher/TeacherSubjectDetails';
 import AddQuestionForm from './pages/teacher/AddQuestionForm';
 import ListOfQuestions from './pages/teacher/ListOfQuestions';
+import AddSubject from './pages/teacher/AddSubject';
 import { selectAppLoading } from './store/appState/selectors';
 import { getStudentWithStoredToken } from './store/student/actions';
 import { getTeacherWithStoredToken } from './store/teacher/actions';
-
 import './App.css';
 
 function App() {
@@ -82,6 +82,11 @@ function App() {
             exact
             path="/teachers/:teacherid/questions/list"
             component={ListOfQuestions}
+          />
+          <Route
+            exact
+            path="/teachers/:teacherid/subject/add"
+            component={AddSubject}
           />
         </Switch>
       </Layout>

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,3 +1,4 @@
-export const apiUrl = 'https://school-dashboard-backend.herokuapp.com';
+// export const apiUrl = 'https://school-dashboard-backend.herokuapp.com';
+export const apiUrl = 'http://localhost:4000';
 
 export const DEFAULT_MESSAGE_TIMEOUT = 3000;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,4 +1,4 @@
-// export const apiUrl = 'https://school-dashboard-backend.herokuapp.com';
-export const apiUrl = 'http://localhost:4000';
+export const apiUrl = 'https://school-dashboard-backend.herokuapp.com';
+// export const apiUrl = 'http://localhost:4000';
 
 export const DEFAULT_MESSAGE_TIMEOUT = 3000;

--- a/src/pages/student/StudentSubjectDetails.jsx
+++ b/src/pages/student/StudentSubjectDetails.jsx
@@ -140,7 +140,7 @@ export default function StudentSubjectDetails() {
         <Row style={{ paddingTop: 15 }} justify="center">
           <Radio.Group size="small" onChange={(e) => setRadio(e.target.value)}>
             <Radio.Button style={{ marginRight: 5 }} value="date">
-              Scores by data
+              Scores by date
             </Radio.Button>
             <Radio.Button style={{ marginRight: 5 }} value="lowestFirst">
               Scores Low to High

--- a/src/pages/teacher/AddSubject.jsx
+++ b/src/pages/teacher/AddSubject.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  selectTeacherToken,
+  selectTeacherId,
+} from '../../store/teacher/selectors';
+// import { createSubject } from '../../store/questions/actions';
+import { Layout, Form, Input, Button, Select, Row, Col } from 'antd';
+
+const { Content } = Layout;
+const { Option } = Select;
+
+export default function AddSubject() {
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const token = useSelector(selectTeacherToken);
+  const teacherId = useSelector(selectTeacherId);
+  const [subject, setSubject] = useState('');
+
+  useEffect(() => {
+    if (token === null) {
+      history.push('/');
+    }
+  });
+
+  const addSubject = () => {
+    console.log(subject);
+    // dispatch(
+    //   createSubject(subject)
+    // );
+    // history.push(`/teachers/${teacherId}/questions/list`);
+  };
+
+  return (
+    <Layout>
+      <Layout style={{ padding: '24px', height: '92vh' }}>
+        <Content className="site-layout-background">
+          <Row justify="center" style={{ padding: '24px' }}>
+            {'Add a subject'.toUpperCase()}
+          </Row>
+
+          <Row justify="center">
+            <Col style={{ width: 650 }}>
+              <Form name="basic" initialValues={{ remember: true }}>
+                <Form.Item
+                  name="Question"
+                  rules={[
+                    { required: true, message: 'Please input a subject!' },
+                  ]}
+                >
+                  <Input
+                    placeholder="Subject"
+                    value={subject}
+                    onChange={(e) => setSubject(e.target.value)}
+                  />
+                </Form.Item>
+                <Form.Item>
+                  <Button
+                    style={{
+                      backgroundColor: '#B81D9D',
+                      border: 'none',
+                    }}
+                    type="primary"
+                    htmlType="submit"
+                    onClick={addSubject}
+                  >
+                    Add Subject to the curriculum
+                  </Button>
+                </Form.Item>
+              </Form>
+            </Col>
+          </Row>
+        </Content>
+      </Layout>
+    </Layout>
+  );
+}

--- a/src/pages/teacher/AddSubject.jsx
+++ b/src/pages/teacher/AddSubject.jsx
@@ -5,11 +5,10 @@ import {
   selectTeacherToken,
   selectTeacherId,
 } from '../../store/teacher/selectors';
-// import { createSubject } from '../../store/questions/actions';
-import { Layout, Form, Input, Button, Select, Row, Col } from 'antd';
+import { createSubject } from '../../store/teacher/actions';
+import { Layout, Form, Input, Button, Row, Col } from 'antd';
 
 const { Content } = Layout;
-const { Option } = Select;
 
 export default function AddSubject() {
   const history = useHistory();
@@ -25,11 +24,8 @@ export default function AddSubject() {
   });
 
   const addSubject = () => {
-    console.log(subject);
-    // dispatch(
-    //   createSubject(subject)
-    // );
-    // history.push(`/teachers/${teacherId}/questions/list`);
+    dispatch(createSubject(subject));
+    history.push(`/teachers/${teacherId}/`);
   };
 
   return (

--- a/src/pages/teacher/TeacherSidebar.jsx
+++ b/src/pages/teacher/TeacherSidebar.jsx
@@ -80,7 +80,13 @@ export default function SideBar() {
             key="sub4-1"
             onClick={() => goTo(`/teachers/${teacherId}/questions/add`)}
           >
-            Add
+            Add Question
+          </Menu.Item>
+          <Menu.Item
+            key="sub4-3"
+            onClick={() => goTo(`/teachers/${teacherId}/subject/add`)}
+          >
+            Add Subject
           </Menu.Item>
         </SubMenu>
       </Menu>

--- a/src/pages/teacher/TeacherSidebar.jsx
+++ b/src/pages/teacher/TeacherSidebar.jsx
@@ -69,12 +69,12 @@ export default function SideBar() {
         <SubMenu key="sub3" icon={<UserOutlined />} title="Students">
           {students ? renderStudentNav() : null}
         </SubMenu>
-        <SubMenu key="sub4" icon={<DatabaseOutlined />} title="Questions">
+        <SubMenu key="sub4" icon={<DatabaseOutlined />} title="Admin">
           <Menu.Item
             key="sub4-2"
             onClick={() => goTo(`/teachers/${teacherId}/questions/list`)}
           >
-            List
+            List Questions
           </Menu.Item>
           <Menu.Item
             key="sub4-1"

--- a/src/store/teacher/actions.js
+++ b/src/store/teacher/actions.js
@@ -13,6 +13,7 @@ import { removeListOfQuestions } from '../questions/actions';
 export const LOGIN_SUCCESS_TEACHER = 'LOGIN_SUCCESS_TEACHER';
 export const TOKEN_STILL_VALID_TEACHER = 'TOKEN_STILL_VALID_TEACHER';
 export const LOG_OUT_TEACHER = 'LOG_OUT_TEACHER';
+export const ADD_SUBJECT = 'ADD_SUBJECT';
 
 const loginSuccessTeacher = (teacherWithToken) => {
   return {
@@ -24,6 +25,11 @@ const loginSuccessTeacher = (teacherWithToken) => {
 const tokenStillValid = (teacherWithoutToken) => ({
   type: TOKEN_STILL_VALID_TEACHER,
   payload: teacherWithoutToken,
+});
+
+const addSubject = (subject) => ({
+  type: ADD_SUBJECT,
+  payload: subject,
 });
 
 export const logOutTeacher = () => ({ type: LOG_OUT_TEACHER });
@@ -127,6 +133,7 @@ export function createSubject(subject) {
         },
         { headers: { Authorization: `Bearer ${token}` } }
       );
+      dispatch(addSubject(response.data.newSubject));
       dispatch(showMessageWithTimeout('success', true, response.data.message));
       dispatch(appDoneLoading());
     } catch (error) {

--- a/src/store/teacher/actions.js
+++ b/src/store/teacher/actions.js
@@ -114,3 +114,30 @@ export const createTeacher = (isStudent, name, email, password) => {
     }
   };
 };
+
+export function createSubject(subject) {
+  return async function thunk(dispatch, getState) {
+    const token = getState().teacher.token;
+    dispatch(appLoading());
+    try {
+      const response = await axios.post(
+        `${apiUrl}/subject`,
+        {
+          subject,
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      dispatch(showMessageWithTimeout('success', true, response.data.message));
+      dispatch(appDoneLoading());
+    } catch (error) {
+      if (error.response) {
+        console.log(error.response.data.message);
+        dispatch(setMessage('danger', true, error.response.data.message));
+      } else {
+        console.log(error.message);
+        dispatch(setMessage('danger', true, error.message));
+      }
+      dispatch(appDoneLoading());
+    }
+  };
+}

--- a/src/store/teacher/reducer.js
+++ b/src/store/teacher/reducer.js
@@ -2,6 +2,7 @@ import {
   LOG_OUT_TEACHER,
   LOGIN_SUCCESS_TEACHER,
   TOKEN_STILL_VALID_TEACHER,
+  ADD_SUBJECT,
 } from './actions';
 
 const initialState = {
@@ -23,6 +24,10 @@ export default (state = initialState, action) => {
 
     case TOKEN_STILL_VALID_TEACHER:
       return { ...state, ...action.payload };
+
+    case ADD_SUBJECT:
+      console.log(action.payload);
+      return { ...state, subjects: [...state.subjects, action.payload] };
 
     default:
       return state;

--- a/src/store/teacher/reducer.js
+++ b/src/store/teacher/reducer.js
@@ -26,8 +26,11 @@ export default (state = initialState, action) => {
       return { ...state, ...action.payload };
 
     case ADD_SUBJECT:
-      console.log(action.payload);
-      return { ...state, subjects: [...state.subjects, action.payload] };
+      if (state.subjects) {
+        return { ...state, subjects: [...state.subjects, action.payload] };
+      } else {
+        return { ...state, subjects: [action.payload] };
+      }
 
     default:
       return state;


### PR DESCRIPTION
As I was using seeds with dummy data to work on the dashboard, I missed the fact that adding a subject would be a handy feature. Now teacher are independent from the developer to set up the dashboard.

Teachers can add a subject. This means that the dashboard can be build from scratch, that is an empty state. 
Teachers sign up, add subjects, and add questions for those subjects.
Students sign in, choose their teacher and start doing tests.